### PR TITLE
Add `useRelativePath` configuration to AssetComposer

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,6 +20,7 @@ services:
             $environment: '%kernel.environment%'
             $appSecret: '%kernel.secret%'
             $paths: '%asset_composer.paths%'
+            $useRelativePath: '%asset_composer.use_relative_path%'
 
     # The Twig extension is autoconfigured, so the tag is not needed
     # but we keep the explicit service definition for clarity

--- a/src/DependencyInjection/AssetComposerExtension.php
+++ b/src/DependencyInjection/AssetComposerExtension.php
@@ -20,6 +20,7 @@ class AssetComposerExtension extends Extension implements PrependExtensionInterf
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('asset_composer.paths', $config['paths'] ?? []);
+        $container->setParameter('asset_composer.use_relative_path', $config['use_relative_path'] ?? true);
 
         $loader = new YamlFileLoader(
             $container,

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,6 +19,9 @@ class Configuration implements ConfigurationInterface
                ->arrayNode('paths')
                     ->scalarPrototype()->end()
                 ->end()
+                ->booleanNode('use_relative_path')
+                    ->defaultTrue()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Service/AssetComposer.php
+++ b/src/Service/AssetComposer.php
@@ -24,6 +24,7 @@ class AssetComposer
         protected string $environment,
         protected string $appSecret,
         protected array $paths = [],
+        protected bool $useRelativePath = true,
     ) {
         if ([] === $this->paths) {
             $this->paths = [
@@ -281,11 +282,12 @@ class AssetComposer
         }
 
         $baseUrlPart = $namespace.'/'.$package.'/'.$assetPath;
+        $referenceType = $this->useRelativePath ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_URL;
         $baseUrl = $this->router->generate('jbs_new_media_assets_composer', [
             'namespace' => $namespace,
             'package' => $package,
             'asset' => $assetPath,
-        ], UrlGeneratorInterface::ABSOLUTE_URL);
+        ], $referenceType);
 
         $fileMTime = filemtime($vendorFile);
         if (false === $fileMTime) {


### PR DESCRIPTION
Introduce a new `useRelativePath` boolean configuration option to toggle between relative and absolute URL generation for asset paths. Update services, configuration, and dependency injection to support this feature. Default to relative paths for improved flexibility.