### PR TITLE
Support symlinked composer path repositories in getAssetFileName()

### DIFF
--- a/src/Service/AssetComposer.php
+++ b/src/Service/AssetComposer.php
@@ -260,6 +260,10 @@ class AssetComposer
 
     public function getAssetFileName(string $asset): string
     {
+        if (str_contains($asset, '..')) {
+            throw new BadRequestHttpException('Security violation: attempted directory traversal');
+        }
+
         $assetParts = explode('/', $asset);
         if (count($assetParts) < 3) {
             throw new BadRequestHttpException('Asset not found (invalid asset path)');
@@ -289,12 +293,10 @@ class AssetComposer
             }
 
             $realVendorFilePath = realpath($vendorFile);
-            $realProjectDir = realpath($this->projectDir);
 
             if (
                 false === $realVendorFilePath
-                || false === $realProjectDir
-                || !str_starts_with($realVendorFilePath, $realProjectDir)
+                || !str_starts_with(str_replace(DIRECTORY_SEPARATOR, '/', $vendorFile), rtrim((string) preg_replace('#/+#', '/', $this->projectDir), '/').'/')
             ) {
                 throw new BadRequestHttpException('Security violation: attempted directory traversal');
             }


### PR DESCRIPTION
The previous containment check compared fully resolved realpaths, which broke for packages installed via composer path repositories with symlink enabled: the resolved path points outside the project directory.

Replace it with a lexical check on the requested path (rejecting '..' segments outright and asserting the non-resolved path stays inside the configured project dir), so symlinked vendor packages resolve correctly while directory traversal stays impossible.